### PR TITLE
Refine audit hardening with Pub/Sub-safe acknowledgements

### DIFF
--- a/.github/workflows/docker-ci-test.yml
+++ b/.github/workflows/docker-ci-test.yml
@@ -40,8 +40,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        
+
+      - name: Compute Docker-safe tag from branch
+        id: docker_tag
+        run: |
+          SAFE_TAG=$(echo "${BRANCH_NAME}" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9_.-]+#-#g; s#^-+##; s#-+$##; s#\.{2,}#.#g')
+          if [ -z "$SAFE_TAG" ]; then
+            SAFE_TAG="pr-${{ github.event.pull_request.number }}"
+          fi
+          echo "tag=$SAFE_TAG" >> "$GITHUB_OUTPUT"
+
       - name: Build Docker image
         run: |
-          docker build -t deepthought42/content-audit:${{ env.BRANCH_NAME }} .
-          docker tag deepthought42/content-audit:${{ env.BRANCH_NAME }} deepthought42/content-audit:latest
+          docker build -t deepthought42/content-audit:${{ steps.docker_tag.outputs.tag }} .
+          docker tag deepthought42/content-audit:${{ steps.docker_tag.outputs.tag }} deepthought42/content-audit:latest

--- a/README.md
+++ b/README.md
@@ -1,97 +1,80 @@
 # Content Audit
 
-This project implements a content audit system using Spring Boot, with integration for Google Cloud Platform (GCP).
+Spring Boot service that consumes Pub/Sub page-audit messages and runs content-focused accessibility audits (alt text, readability, and paragraphing).
 
-## AuditController
+## What this service does
 
-The `AuditController` is a key component of this application, responsible for:
+The POST `/` endpoint accepts a Pub/Sub push payload (`Body`), decodes a `PageAuditMessage`, loads the related `AuditRecord` and `PageState`, then executes:
 
-1. Initiating content audits
-2. Retrieving audit results
-3. Managing audit configurations
+- Alt text audits (`img`, `applet`, `canvas`, `iframe`, `object`, `svg`)
+- Readability audit
+- Paragraphing audit
 
-It provides RESTful endpoints for interacting with the audit system, allowing users to start audits, check their status, and retrieve results.
+When complete, the service publishes an `AuditProgressUpdate` message to notify downstream systems.
+
+## Request format
+
+The controller expects a Pub/Sub push body with base64-encoded JSON in `message.data`.
+
+```json
+{
+  "message": {
+    "data": "<base64 encoded PageAuditMessage JSON>"
+  }
+}
+```
+
+`PageAuditMessage` fields used by this service:
+
+- `pageAuditId`
+- `pageId`
+- `accountId`
+
+## Reliability and validation improvements
+
+Recent code review fixes include:
+
+- Defensive validation for malformed Pub/Sub payloads and invalid base64/JSON. Invalid events are acknowledged with `200 OK` so Pub/Sub does not redeliver poison messages.
+- Missing `AuditRecord` / `PageState` messages are also acknowledged and logged to avoid infinite retry loops.
+- Improved exception logging (stack traces logged through SLF4J, not `printStackTrace`).
+- Corrected user-facing audit status typo (`"Content Audit Complete!"`).
+- Null-safe and whitespace-safe text handling in readability/paragraphing audits.
+- Fixed readability scoring bug for very difficult text (`ease < 30`) where higher-education scoring branches were being unintentionally overridden.
 
 ## Configuration
 
-This project uses GCP Secret Manager for secure configuration management. The main configuration files are:
+Main runtime configuration files:
 
-- `application.properties`
+- `src/main/resources/application.properties`
+- `src/main/resources/application.yml`
 
-### Setting up GCP Secrets
+The project uses Google Cloud services (including Secret Manager and NLP). Configure credentials before local runs:
 
-1. Create a GCP project if you haven't already.
-2. Enable the Secret Manager API for your project.
-3. Create secrets in Secret Manager for each property in `application.properties`.
-4. Update the `spring.cloud.gcp.secretmanager.secret-name-prefix` in your local `application.properties` to match your GCP project ID.
-
-### GCP Project Credentials
-
-To authenticate with GCP services:
-
-1. Go to the GCP Console > IAM & Admin > Service Accounts.
-2. Create a new service account or select an existing one.
-3. Generate a new JSON key for the service account.
-4. Save the JSON file securely on your local machine.
-5. Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the path of this JSON file:
-
-   ```
-   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/credentials.json
-   ```
-
-### Gmail Credentials
-
-To use Gmail API for email-related features:
-
-1. Go to the Google Cloud Console.
-2. Enable the Gmail API for your project.
-3. Create OAuth 2.0 credentials (OAuth client ID).
-4. Download the JSON file for the OAuth 2.0 client ID.
-5. Save this JSON file securely and update the `gmail.credentials.file` property in your `application.properties` with the file path.
-
-## Running the Application
-
-1. Ensure all GCP secrets are properly configured.
-2. Set up the GCP project credentials and Gmail credentials as described above.
-3. Build the project using Maven:
-
-   ```
-   mvn clean install
-   ```
-
-4. Run the application:
-
-   ```
-   java -jar target/contentAudit-0.0.1-SNAPSHOT.jar
-   ```
-
-## API Documentation
-
-Once the application is running, you can access the Swagger UI for API documentation at:
-
-```
-http://localhost:8080/swagger-ui.html
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 ```
 
-This will provide detailed information about the available endpoints and how to use them.
+## Build and test
 
-### PageAuditMessage Object Schema
+```bash
+mvn clean test
+```
 
-The `PageAuditMessage` object represents a message that is passed to the AuditController endpoint for processing page audits. It contains essential information about the audit request and is used to initiate and track individual page audits. The object has the following fields:
+If Maven dependency resolution to `https://repo.maven.apache.org/maven2` is blocked (e.g., HTTP 403 from the environment), tests will fail before compilation. In that case, run in an environment with working Maven Central access or a configured internal mirror/proxy.
 
-- `pageAuditId` (String): The unique identifier for the page audit.
-- `pageId` (String): The identifier of the page being audited.
-- `messageId` (String): The unique identifier for the message.
-- `publishTime` (DateTime): The timestamp when the message was published.
-- `accountId` (String): The identifier of the account associated with the message.
+## Running locally
 
-This object is used in various API endpoints related to page audits and messaging, particularly when submitting new audit requests to the AuditController.
+```bash
+mvn spring-boot:run
+```
 
-## Security
+Or package and run:
 
-Authentication is not currently implemented in this application. Features such as OAuth, SAML, or other authentication mechanisms will need to be added to secure the system. Please be sure to implement appropriate authentication and authorization before deploying to production.
+```bash
+mvn clean package
+java -jar target/content-audit-<version>.jar
+```
 
-## Support
+## Security note
 
-For any issues or questions, please open an issue in the project repository.
-
+This service is typically deployed behind trusted infrastructure (Pub/Sub push + internal routing). If exposed publicly, add request authentication/authorization and signature verification for push requests before production use.

--- a/src/main/java/com/looksee/contentAudit/AuditController.java
+++ b/src/main/java/com/looksee/contentAudit/AuditController.java
@@ -17,6 +17,7 @@ package com.looksee.contentAudit;
  */
 // [START cloudrun_pubsub_handler]
 // [START run_pubsub_handler]
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.Set;
@@ -118,12 +119,17 @@ public class AuditController {
 
 		PageAuditMessage audit_record_msg;
 		try {
-			String target = new String(Base64.getDecoder().decode(data));
+			String target = new String(Base64.getDecoder().decode(data), StandardCharsets.UTF_8);
 			ObjectMapper input_mapper = new ObjectMapper();
 			audit_record_msg = input_mapper.readValue(target, PageAuditMessage.class);
 		} catch (IllegalArgumentException | JsonProcessingException e) {
 			log.warn("invalid pubsub message format", e);
 			return acknowledgeInvalidMessage("Invalid pubsub message format");
+		}
+
+		if (audit_record_msg.getPageAuditId() == null || audit_record_msg.getPageAuditId().isBlank()) {
+			log.warn("pageAuditId missing from pubsub message");
+			return acknowledgeInvalidMessage("Missing pageAuditId");
 		}
 		
 		try {

--- a/src/main/java/com/looksee/contentAudit/AuditController.java
+++ b/src/main/java/com/looksee/contentAudit/AuditController.java
@@ -127,9 +127,9 @@ public class AuditController {
 			return acknowledgeInvalidMessage("Invalid pubsub message format");
 		}
 
-		if (audit_record_msg.getPageAuditId() == null || audit_record_msg.getPageAuditId().isBlank()) {
-			log.warn("pageAuditId missing from pubsub message");
-			return acknowledgeInvalidMessage("Missing pageAuditId");
+		if (audit_record_msg.getPageAuditId() <= 0) {
+			log.warn("invalid pageAuditId in pubsub message: {}", audit_record_msg.getPageAuditId());
+			return acknowledgeInvalidMessage("Invalid pageAuditId");
 		}
 		
 		try {

--- a/src/main/java/com/looksee/contentAudit/AuditController.java
+++ b/src/main/java/com/looksee/contentAudit/AuditController.java
@@ -18,8 +18,8 @@ package com.looksee.contentAudit;
 // [START cloudrun_pubsub_handler]
 // [START run_pubsub_handler]
 import java.util.Base64;
+import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +32,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -102,27 +101,45 @@ public class AuditController {
 	 *
 	 * @param body the body of the message containing the audit record and page state
 	 * @return ResponseEntity containing the result of the audit
-	 * @throws JsonMappingException if there is an error mapping the JSON data
-	 * @throws JsonProcessingException if there is an error processing the JSON data
-	 * @throws ExecutionException if the execution of the audit fails
-	 * @throws InterruptedException if the thread is interrupted while waiting for the audit to complete
 	 */
 	@RequestMapping(value = "/", method = RequestMethod.POST)
-	public ResponseEntity<String> receiveMessage(@RequestBody Body body)
-		throws JsonMappingException, JsonProcessingException, ExecutionException, InterruptedException
-	{
+	public ResponseEntity<String> receiveMessage(@RequestBody Body body) {
+		if (body == null || body.getMessage() == null || body.getMessage().getData() == null) {
+			log.warn("invalid pubsub payload received");
+			return acknowledgeInvalidMessage("Invalid pubsub payload");
+		}
+
 		Body.Message message = body.getMessage();
 		String data = message.getData();
-		String target = !data.isEmpty() ? new String(Base64.getDecoder().decode(data)) : "";
-        log.warn("page audit msg received = "+target);
+		if (data.isBlank()) {
+			log.warn("received empty pubsub payload data");
+			return acknowledgeInvalidMessage("Empty pubsub payload data");
+		}
 
-		ObjectMapper input_mapper = new ObjectMapper();
-		PageAuditMessage audit_record_msg = input_mapper.readValue(target, PageAuditMessage.class);
+		PageAuditMessage audit_record_msg;
+		try {
+			String target = new String(Base64.getDecoder().decode(data));
+			ObjectMapper input_mapper = new ObjectMapper();
+			audit_record_msg = input_mapper.readValue(target, PageAuditMessage.class);
+		} catch (IllegalArgumentException | JsonProcessingException e) {
+			log.warn("invalid pubsub message format", e);
+			return acknowledgeInvalidMessage("Invalid pubsub message format");
+		}
 		
 		try {
-			AuditRecord audit_record = audit_record_service.findById(audit_record_msg.getPageAuditId()).get();
+			Optional<AuditRecord> audit_record_optional = audit_record_service.findById(audit_record_msg.getPageAuditId());
+			if (audit_record_optional.isEmpty()) {
+				log.warn("audit record not found for page audit id {}", audit_record_msg.getPageAuditId());
+				return acknowledgeInvalidMessage("Audit record not found");
+			}
+
+			AuditRecord audit_record = audit_record_optional.get();
 			//PageState page = page_state_service.findById(audit_record_msg.getPageId()).get();
 			PageState page = page_state_service.findByAuditRecordId(audit_record_msg.getPageAuditId());
+			if (page == null) {
+				log.warn("page state not found for page audit id {}", audit_record_msg.getPageAuditId());
+				return acknowledgeInvalidMessage("Page state not found");
+			}
 			page.setElements(page_state_service.getElementStates(page.getId()));
 			log.warn("evaluating "+page.getElements().size()+" element state for content audit with page ID :: "+page.getId());
 			Set<Audit> audits = audit_record_service.getAllAudits(audit_record.getId());
@@ -157,21 +174,14 @@ public class AuditController {
 				audit_record_service.addAudit(audit_record_msg.getPageAuditId(), paragraph_audit.getId());
 			}
 		} catch (Exception e) {
-			log.error("exception caught during content audit");
-			e.printStackTrace();
-			log.error("-------------------------------------------------------------");
-			log.error("-------------------------------------------------------------");
-			log.error("THERE WAS AN ISSUE DURING CONTENT AUDIT");
-			log.error("-------------------------------------------------------------");
-			log.error("-------------------------------------------------------------");
-			
+			log.error("exception caught during content audit", e);
 			return new ResponseEntity<String>("Error performing content audit", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 
 		JsonMapper mapper = JsonMapper.builder().addModule(new JavaTimeModule()).build();
 		AuditProgressUpdate audit_update = new AuditProgressUpdate(audit_record_msg.getAccountId(),
 															1.0, 
-															"Content Audit Compelete!",
+															"Content Audit Complete!",
 																	AuditCategory.CONTENT,
 																	AuditLevel.PAGE,
 																	audit_record_msg.getPageAuditId());
@@ -194,6 +204,11 @@ public class AuditController {
 	 * @pre audits != null
 	 * @pre audit_name != null
 	 */
+
+	private ResponseEntity<String> acknowledgeInvalidMessage(String reason) {
+		return new ResponseEntity<String>(reason, HttpStatus.OK);
+	}
+
 	private boolean auditAlreadyExists(Set<Audit> audits, AuditName audit_name) {
 		assert audits != null;
 		assert audit_name != null;

--- a/src/main/java/com/looksee/contentAudit/AuditController.java
+++ b/src/main/java/com/looksee/contentAudit/AuditController.java
@@ -195,6 +195,10 @@ public class AuditController {
 		try {
 			String audit_record_json = mapper.writeValueAsString(audit_update);
 			audit_update_topic.publish(audit_record_json);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			log.error("interrupted while publishing audit progress update", e);
+			return new ResponseEntity<String>("Error publishing audit progress", HttpStatus.INTERNAL_SERVER_ERROR);
 		} catch (JsonProcessingException | java.util.concurrent.ExecutionException e) {
 			log.error("failed to publish audit progress update", e);
 			return new ResponseEntity<String>("Error publishing audit progress", HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/looksee/contentAudit/AuditController.java
+++ b/src/main/java/com/looksee/contentAudit/AuditController.java
@@ -186,14 +186,19 @@ public class AuditController {
 
 		JsonMapper mapper = JsonMapper.builder().addModule(new JavaTimeModule()).build();
 		AuditProgressUpdate audit_update = new AuditProgressUpdate(audit_record_msg.getAccountId(),
-															1.0, 
-															"Content Audit Complete!",
-																	AuditCategory.CONTENT,
-																	AuditLevel.PAGE,
-																	audit_record_msg.getPageAuditId());
+												1.0, 
+												"Content Audit Complete!",
+														AuditCategory.CONTENT,
+														AuditLevel.PAGE,
+														audit_record_msg.getPageAuditId());
 
-		String audit_record_json = mapper.writeValueAsString(audit_update);
-		audit_update_topic.publish(audit_record_json);
+		try {
+			String audit_record_json = mapper.writeValueAsString(audit_update);
+			audit_update_topic.publish(audit_record_json);
+		} catch (JsonProcessingException | java.util.concurrent.ExecutionException e) {
+			log.error("failed to publish audit progress update", e);
+			return new ResponseEntity<String>("Error publishing audit progress", HttpStatus.INTERNAL_SERVER_ERROR);
+		}
 
 		return new ResponseEntity<String>("Successfully completed content audit", HttpStatus.OK);
 	}

--- a/src/main/java/com/looksee/contentAudit/models/ParagraphingAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/ParagraphingAudit.java
@@ -117,11 +117,15 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 		
 		for(ElementState element : element_list) {
 			String text_block = element.getOwnedText();
+			if(text_block == null || text_block.isBlank()) {
+				continue;
+			}
 			
 			//    parse text block into paragraph chunks(multiple paragraphs can exist in a text block)
 			String[] paragraphs = text_block.split("\n");
 			for(String paragraph : paragraphs) {
-				if(paragraph.split(" ").length < 3) {
+				paragraph = paragraph.trim();
+				if(paragraph.isEmpty() || paragraph.split("\\s+").length < 3) {
 					continue;
 				}
 				else if(!paragraph.contains(".")) {
@@ -133,8 +137,7 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 
 					issue_messages.addAll(score.getIssueMessages());
 				} catch (Exception e) {
-					log.warn("error getting sentences from text :: "+paragraph);
-					//e.printStackTrace();
+					log.warn("error getting sentences from text :: {}", paragraph, e);
 				}
 
 			}
@@ -209,7 +212,8 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 		String ada_compliance = "There are no ADA compliance requirements for this category.";
 		
 		for(Sentence sentence : sentences) {
-			String[] words = sentence.getText().getContent().split(" ");
+			String sentenceText = sentence.getText().getContent();
+			String[] words = sentenceText == null || sentenceText.isBlank() ? new String[0] : sentenceText.trim().split("\\s+");
 			
 			if(words.length > 25) {
 

--- a/src/main/java/com/looksee/contentAudit/models/ParagraphingAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/ParagraphingAudit.java
@@ -212,7 +212,7 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 		String ada_compliance = "There are no ADA compliance requirements for this category.";
 		
 		for(Sentence sentence : sentences) {
-			String sentenceText = sentence.getText().getContent();
+			String sentenceText = sentence != null && sentence.getText() != null ? sentence.getText().getContent() : null;
 			String[] words = sentenceText == null || sentenceText.isBlank() ? new String[0] : sentenceText.trim().split("\\s+");
 			
 			if(words.length > 25) {

--- a/src/main/java/com/looksee/contentAudit/models/ReadabilityAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/ReadabilityAudit.java
@@ -146,8 +146,11 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 			for(ElementState element: page_state.getElements()) {
 				if(element.getName().contentEquals("button")
 						|| element.getName().contentEquals("a")
-						|| (element.getOwnedText() == null || element.getOwnedText().isEmpty())
-						|| element.getAllText().split(" ").length <= 3
+						|| element.getOwnedText() == null
+						|| element.getOwnedText().isBlank()
+						|| element.getAllText() == null
+						|| element.getAllText().isBlank()
+						|| countWords(element.getAllText()) <= 3
 				) {
 					continue;
 				}
@@ -156,15 +159,20 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 					if(element2.getKey().contentEquals(element.getKey())) {
 						continue;
 					}
-					if(!element2.getOwnedText().isEmpty()
+					if(element2.getOwnedText() != null
+							&& !element2.getOwnedText().isBlank()
+							&& element2.getAllText() != null
+							&& element.getAllText() != null
 							&& element2.getAllText().contains(element.getAllText())
 							&& !element2.getAllText().contentEquals(element.getAllText())
 					) {
 						is_child_text = true;
 						break;
 					}
-					else if(element2.getAllText().contentEquals(element.getAllText())
-							&& !element2.getXpath().contains(element.getXpath())
+					else if(element2.getAllText() != null
+							&& element.getAllText() != null
+							&& element2.getAllText().contentEquals(element.getAllText())
+							&& !xpathContains(element2.getXpath(), element.getXpath())
 					) {
 						is_child_text = true;
 						break;
@@ -172,7 +180,7 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 				}
 				
 				if(!is_child_text) {
-					if(element.getAllText().split(" ").length > 3){
+					if(countWords(element.getAllText()) > 3){
 						og_text_elements.add(element);
 					}
 				}
@@ -192,13 +200,13 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 		
 					int element_points = getPointsForEducationLevel(ease_of_reading_score, audit_record.getTargetUserEducation());
 		
-					if(element.getAllText().split(" ").length < 10) {
+					if(countWords(element.getAllText()) < 10) {
 						element_points = 4;
 					}
 					
 					if(element_points < 4) {
 						String title = "Content is written at " + grade_level + " reading level";
-						String description = generateIssueDescription(element, difficulty_string, ease_of_reading_score, audit_record.getTargetUserEducation());
+						String description = generateIssueDescription(element, difficulty_string, audit_record.getTargetUserEducation());
 						String recommendation = "Reduce the length of your sentences by breaking longer sentences into 2 or more shorter sentences. You can also use simpler words. Words that contain many syllables can also be difficult to understand.";
 						
 						ReadingComplexityIssueMessage issue_message = new ReadingComplexityIssueMessage(Priority.LOW, 
@@ -220,12 +228,12 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 					else {
 						String recommendation = "";
 						String description = "";
-						if(element.getAllText().split(" ").length < 10) {
+						if(countWords(element.getAllText()) < 10) {
 							element_points = 4;
 							description = "Content is short enough to be easily understood by all users";
 						}
 						else {
-							description = generateIssueDescription(element, difficulty_string, ease_of_reading_score, audit_record.getTargetUserEducation());
+							description = generateIssueDescription(element, difficulty_string, audit_record.getTargetUserEducation());
 						}
 						String title = "Content is easy to read";
 						
@@ -246,7 +254,7 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 						issue_messages.add(issue_message);
 					}
 				} catch(Exception e) {
-					e.printStackTrace();
+					log.warn("error calculating readability for element {}", element.getId(), e);
 				}
 			}
 
@@ -280,26 +288,24 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 			return audit_service.save(audit);
 		}
 		catch(Exception e){
-			e.printStackTrace();
+			log.error("readability audit failed", e);
 			throw e;
 		}
 	}
 
 	/**
 	 * Generates a description of the issue based on the element, difficulty string,
-	 * ease of reading score, and target user education.
+	 * and target user education.
 	 * @param element The element that is being audited
 	 * @param difficulty_string The difficulty string of the element
-	 * @param ease_of_reading_score The ease of reading score of the element
 	 * @param targetUserEducation The target user education of the element
 	 * @return A description of the issue based on the element, difficulty string,
-	 * ease of reading score, and target user education.
+	 * and target user education.
 	 */
 	private String generateIssueDescription(ElementState element,
-											String difficulty_string,
-											double ease_of_reading_score,
-											String targetUserEducation) {
-		String description = "The text \"" + element.getAllText() + "\" is " + difficulty_string + " to read for "+getConsumerType(targetUserEducation);
+									String difficulty_string,
+									String targetUserEducation) {
+		String description = "The text \"" + element.getAllText() + "\" is " + difficulty_string + " to read for " + getConsumerType(targetUserEducation) + ".";
 		
 		return description;
 	}
@@ -444,10 +450,26 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 			else {
 				element_points = 0;
 			}
-			element_points = 0;
 		}
 		
 		return element_points;
+	}
+
+
+	private static int countWords(String text) {
+		if (text == null || text.isBlank()) {
+			return 0;
+		}
+
+		return text.trim().split("\\s+").length;
+	}
+
+	private static boolean xpathContains(String parentXpath, String childXpath) {
+		if (parentXpath == null || childXpath == null) {
+			return false;
+		}
+
+		return parentXpath.contains(childXpath);
 	}
 
 	/**
@@ -460,7 +482,7 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 	 */
 	public static Score calculateSentenceScore(String sentence) {
 		//    		for each sentence check that sentence is no longer than 20 words
-		String[] words = sentence.split(" ");
+		String[] words = sentence == null ? new String[0] : sentence.trim().split("\\s+");
 		
 		if(words.length <= 10) {
 			return new Score(2, 2, new HashSet<>());

--- a/src/main/java/com/looksee/contentAudit/models/ReadabilityAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/ReadabilityAudit.java
@@ -482,7 +482,7 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 	 */
 	public static Score calculateSentenceScore(String sentence) {
 		//    		for each sentence check that sentence is no longer than 20 words
-		String[] words = sentence == null ? new String[0] : sentence.trim().split("\\s+");
+		String[] words = sentence == null || sentence.isBlank() ? new String[0] : sentence.trim().split("\\s+");
 		
 		if(words.length <= 10) {
 			return new Score(2, 2, new HashSet<>());


### PR DESCRIPTION
### Motivation

- Prevent Pub/Sub poison-message redelivery loops by acknowledging malformed or missing message payloads while retaining actionable logs. 
- Reduce runtime exceptions and noisy logs from brittle text handling in readability/paragraphing audits. 
- Make operational behavior clearer in documentation so operators understand acknowledgement/retry semantics.

### Description

- Update `AuditController.receiveMessage` to decode/parse payloads inside guarded blocks, acknowledge invalid base64/JSON and missing dependencies with `200 OK` via `acknowledgeInvalidMessage(...)`, and keep real execution failures as `500` with structured logging. 
- Harden `ReadabilityAudit` by adding `countWords(...)` and `xpathContains(...)` helpers, making owned/all-text checks null/blank-safe, replacing brittle `split(" ")` usages with whitespace-normalizing counts, removing `printStackTrace` calls, and simplifying the issue description signature and punctuation. 
- Harden `ParagraphingAudit` by trimming and skipping null/blank text blocks/paragraphs, normalizing whitespace for paragraph word counts, safely tokenizing sentences when calling the sentence scorer, and improving exception logging. 
- Update `README.md` to document the POST payload format and the change to acknowledge invalid/missing audit messages to avoid infinite retry loops.

### Testing

- Attempted `mvn test -q` in this environment but the build could not start because Maven Central dependency resolution returned HTTP 403, so compilation and automated tests did not run. 
- No unit tests were modified as part of this change; validation was limited to local source edits and running the repository-level Maven command which failed due to external repository access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ffbe7284832ea2c729053861c0e1)