### PR TITLE
Add unit tests for content-audit controller and scoring logic

### DIFF
--- a/src/test/java/com/looksee/contentAudit/AuditControllerUnitTest.java
+++ b/src/test/java/com/looksee/contentAudit/AuditControllerUnitTest.java
@@ -1,0 +1,72 @@
+package com.looksee.contentAudit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.looksee.models.audit.Audit;
+import com.looksee.models.enums.AuditName;
+
+public class AuditControllerUnitTest {
+
+	@Test
+	public void acknowledgeInvalidMessageReturnsOkStatusAndReasonBody() throws Exception {
+		AuditController controller = new AuditController();
+		Method method = AuditController.class.getDeclaredMethod("acknowledgeInvalidMessage", String.class);
+		method.setAccessible(true);
+
+		@SuppressWarnings("unchecked")
+		ResponseEntity<String> response = (ResponseEntity<String>) method.invoke(controller, "Invalid pageAuditId");
+
+		assertEquals(HttpStatus.OK, response.getStatusCode());
+		assertEquals("Invalid pageAuditId", response.getBody());
+	}
+
+	@Test
+	public void auditAlreadyExistsReturnsTrueWhenAuditNameMatches() throws Exception {
+		AuditController controller = new AuditController();
+		Method method = AuditController.class.getDeclaredMethod("auditAlreadyExists", Set.class, AuditName.class);
+		method.setAccessible(true);
+
+		Audit existing = mock(Audit.class);
+		when(existing.getName()).thenReturn(AuditName.ALT_TEXT);
+
+		Audit other = mock(Audit.class);
+		when(other.getName()).thenReturn(AuditName.PARAGRAPHING);
+
+		Set<Audit> audits = new HashSet<>();
+		audits.add(existing);
+		audits.add(other);
+
+		Boolean result = (Boolean) method.invoke(controller, audits, AuditName.ALT_TEXT);
+
+		assertTrue(result);
+	}
+
+	@Test
+	public void auditAlreadyExistsReturnsFalseWhenNoAuditNameMatches() throws Exception {
+		AuditController controller = new AuditController();
+		Method method = AuditController.class.getDeclaredMethod("auditAlreadyExists", Set.class, AuditName.class);
+		method.setAccessible(true);
+
+		Audit existing = mock(Audit.class);
+		when(existing.getName()).thenReturn(AuditName.READING_COMPLEXITY);
+
+		Set<Audit> audits = new HashSet<>();
+		audits.add(existing);
+
+		Boolean result = (Boolean) method.invoke(controller, audits, AuditName.ALT_TEXT);
+
+		assertFalse(result);
+	}
+}

--- a/src/test/java/com/looksee/contentAudit/models/ParagraphingAuditUnitTest.java
+++ b/src/test/java/com/looksee/contentAudit/models/ParagraphingAuditUnitTest.java
@@ -1,0 +1,20 @@
+package com.looksee.contentAudit.models;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ParagraphingAuditUnitTest {
+
+	@Test
+	public void calculateParagraphScoreRewardsFiveOrFewerSentences() {
+		assertEquals(1, ParagraphingAudit.calculateParagraphScore(1).getPoints());
+		assertEquals(1, ParagraphingAudit.calculateParagraphScore(5).getPoints());
+	}
+
+	@Test
+	public void calculateParagraphScorePenalizesMoreThanFiveSentences() {
+		assertEquals(0, ParagraphingAudit.calculateParagraphScore(6).getPoints());
+		assertEquals(0, ParagraphingAudit.calculateParagraphScore(10).getPoints());
+	}
+}

--- a/src/test/java/com/looksee/contentAudit/models/ReadabilityAuditUnitTest.java
+++ b/src/test/java/com/looksee/contentAudit/models/ReadabilityAuditUnitTest.java
@@ -1,0 +1,98 @@
+package com.looksee.contentAudit.models;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+import com.looksee.models.ElementState;
+import com.looksee.models.audit.Score;
+
+public class ReadabilityAuditUnitTest {
+
+	@Test
+	public void calculateSentenceScoreReturnsFullPointsForShortSentence() {
+		Score score = ReadabilityAudit.calculateSentenceScore("This sentence has only a few words.");
+
+		assertEquals(2, score.getPoints());
+		assertEquals(2, score.getMaxPoints());
+		assertTrue(score.getIssueMessages().isEmpty());
+	}
+
+	@Test
+	public void calculateSentenceScoreReturnsPartialPointsForMediumSentence() {
+		Score score = ReadabilityAudit.calculateSentenceScore(
+			"This sentence has more than ten words but remains short enough to avoid the longest penalty tier.");
+
+		assertEquals(1, score.getPoints());
+		assertEquals(2, score.getMaxPoints());
+	}
+
+	@Test
+	public void calculateSentenceScoreReturnsNoPointsForLongSentence() {
+		Score score = ReadabilityAudit.calculateSentenceScore(
+			"This sentence intentionally includes enough additional words to ensure it exceeds twenty words and is scored in the lowest readability sentence scoring category.");
+
+		assertEquals(0, score.getPoints());
+		assertEquals(2, score.getMaxPoints());
+	}
+
+	@Test
+	public void calculateParagraphScoreReturnsExpectedValues() {
+		assertEquals(1, ReadabilityAudit.calculateParagraphScore(5).getPoints());
+		assertEquals(0, ReadabilityAudit.calculateParagraphScore(6).getPoints());
+	}
+
+	@Test
+	public void privateHelpersHandleNullAndConsumerLabels() throws Exception {
+		ReadabilityAudit audit = new ReadabilityAudit();
+
+		Method countWordsMethod = ReadabilityAudit.class.getDeclaredMethod("countWords", String.class);
+		countWordsMethod.setAccessible(true);
+		assertEquals(0, ((Integer) countWordsMethod.invoke(null, (String) null)).intValue());
+		assertEquals(0, ((Integer) countWordsMethod.invoke(null, "   ")).intValue());
+		assertEquals(3, ((Integer) countWordsMethod.invoke(null, "alpha beta gamma")).intValue());
+
+		Method xpathContainsMethod = ReadabilityAudit.class.getDeclaredMethod("xpathContains", String.class, String.class);
+		xpathContainsMethod.setAccessible(true);
+		assertTrue((Boolean) xpathContainsMethod.invoke(null, "/html/body/div", "body"));
+
+		Method consumerTypeMethod = ReadabilityAudit.class.getDeclaredMethod("getConsumerType", String.class);
+		consumerTypeMethod.setAccessible(true);
+		assertEquals("the average consumer", consumerTypeMethod.invoke(audit, new Object[] { null }));
+		assertEquals("users with a College education", consumerTypeMethod.invoke(audit, "College"));
+	}
+
+	@Test
+	public void generateIssueDescriptionIncludesElementTextAndEducationAudience() throws Exception {
+		ReadabilityAudit audit = new ReadabilityAudit();
+		ElementState element = mock(ElementState.class);
+		when(element.getAllText()).thenReturn("Complex sample content");
+
+		Method method = ReadabilityAudit.class.getDeclaredMethod("generateIssueDescription", ElementState.class, String.class, String.class);
+		method.setAccessible(true);
+
+		String description = (String) method.invoke(audit, element, "difficult", "HS");
+
+		assertTrue(description.contains("Complex sample content"));
+		assertTrue(description.contains("difficult"));
+		assertTrue(description.contains("users with a HS education"));
+	}
+
+	@Test
+	public void getPointsForEducationLevelUsesExpectedBands() throws Exception {
+		ReadabilityAudit audit = new ReadabilityAudit();
+		Method method = ReadabilityAudit.class.getDeclaredMethod("getPointsForEducationLevel", double.class, String.class);
+		method.setAccessible(true);
+
+		assertEquals(4, ((Integer) method.invoke(audit, 95.0d, null)).intValue());
+		assertEquals(3, ((Integer) method.invoke(audit, 95.0d, "Advanced")).intValue());
+		assertEquals(2, ((Integer) method.invoke(audit, 65.0d, "HS")).intValue());
+		assertEquals(3, ((Integer) method.invoke(audit, 45.0d, "Advanced")).intValue());
+		assertEquals(0, ((Integer) method.invoke(audit, 20.0d, "HS")).intValue());
+	}
+}


### PR DESCRIPTION
### Motivation

- Add focused unit tests to cover controller internals and scoring helpers so content-audit logic is validated.
- Exercise private helper behavior (word counting, xpath checks, consumer labels, issue description generation) and sentence/paragraph scoring rules.
- Prepare the project to improve test coverage toward the target QA threshold.

### Description

- Added `src/test/java/com/looksee/contentAudit/AuditControllerUnitTest.java` to verify `acknowledgeInvalidMessage` response and `auditAlreadyExists` behavior using reflection and Mockito.
- Added `src/test/java/com/looksee/contentAudit/models/ReadabilityAuditUnitTest.java` to cover `calculateSentenceScore`, `calculateParagraphScore`, private helper methods (`countWords`, `xpathContains`, `getConsumerType`, `generateIssueDescription`) and `getPointsForEducationLevel` bands via reflection.
- Added `src/test/java/com/looksee/contentAudit/models/ParagraphingAuditUnitTest.java` to assert paragraph scoring boundaries for sentence counts.
- Tests are unit-focused, use JUnit4 and Mockito, and do not change production code or runtime behavior.

### Testing

- Ran `mvn -q -Dtest=AuditControllerUnitTest,ReadabilityAuditUnitTest,ParagraphingAuditUnitTest test` which failed before tests executed because Maven dependency resolution to Maven Central is blocked (HTTP 403), so tests did not run.
- `mvn test -q` and other Maven attempts also failed due to non-resolvable BOM/import POMs from Maven Central (HTTP 403), preventing automated test execution in this environment.
- The new tests are committed to the repository and are expected to run successfully in an environment with normal Maven Central access; automated test runs were blocked by network/repository access restrictions in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9bf9cadb4832eb36618730225983d)