### PR TITLE
Remove dead code and unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,26 +97,6 @@
 		    <version>2.12.2</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/us.codecraft/xsoup -->
-		<dependency>
-		    <groupId>us.codecraft</groupId>
-		    <artifactId>xsoup</artifactId>
-		    <version>0.3.1</version>
-		</dependency>
-		
-		<dependency>
-		    <groupId>xml-apis</groupId>
-		    <artifactId>xml-apis</artifactId>
-		    <version>1.4.01</version>
-		</dependency>
-
-		<!-- https://mvnrepository.com/artifact/net.sf.jtidy/jtidy -->
-		<dependency>
-		    <groupId>net.sf.jtidy</groupId>
-		    <artifactId>jtidy</artifactId>
-		    <version>r938</version>
-		</dependency>
-		
 		<dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
@@ -130,20 +110,6 @@
 		    <version>0.1.6</version>
 		</dependency>
 		
-		<!-- https://mvnrepository.com/artifact/edu.stanford.nlp/stanford-corenlp -->
-		<dependency>
-		    <groupId>edu.stanford.nlp</groupId>
-		    <artifactId>stanford-corenlp</artifactId>
-		    <version>4.2.2</version>
-		</dependency>
-		
-		<!-- https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations -->
-		<dependency>
-			<groupId>io.swagger.core.v3</groupId>
-			<artifactId>swagger-annotations</artifactId>
-			<version>2.2.31</version>
-		</dependency>
-
 		<!-- Google Cloud Language API for NLP functionality -->
 		<dependency>
 			<groupId>com.google.cloud</groupId>

--- a/src/main/java/com/looksee/contentAudit/Application.java
+++ b/src/main/java/com/looksee/contentAudit/Application.java
@@ -1,7 +1,5 @@
 package com.looksee.contentAudit;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
@@ -13,9 +11,6 @@ import org.springframework.context.annotation.PropertySources;
 	@PropertySource("classpath:application.properties")
 })
 public class Application {
-	@SuppressWarnings("unused")
-	private final Logger log = LoggerFactory.getLogger(this.getClass());
-
 	public static void main(String[] args)  {
 		SpringApplication.run(Application.class, args);
 	}

--- a/src/main/java/com/looksee/contentAudit/AuditController.java
+++ b/src/main/java/com/looksee/contentAudit/AuditController.java
@@ -140,7 +140,6 @@ public class AuditController {
 			}
 
 			AuditRecord audit_record = audit_record_optional.get();
-			//PageState page = page_state_service.findById(audit_record_msg.getPageId()).get();
 			PageState page = page_state_service.findByAuditRecordId(audit_record_msg.getPageAuditId());
 			if (page == null) {
 				log.warn("page state not found for page audit id {}", audit_record_msg.getPageAuditId());

--- a/src/main/java/com/looksee/contentAudit/models/AppletAltTextAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/AppletAltTextAudit.java
@@ -8,8 +8,6 @@ import java.util.Set;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -49,9 +47,6 @@ import lombok.NoArgsConstructor;
 @Component
 @NoArgsConstructor
 public class AppletAltTextAudit implements IExecutablePageStateAudit {
-	@SuppressWarnings("unused")
-	private static Logger log = LoggerFactory.getLogger(ImageAltTextAudit.class);
-	
 	@Autowired
 	private AuditService audit_service;
 	
@@ -177,8 +172,7 @@ public class AppletAltTextAudit implements IExecutablePageStateAudit {
 			points_earned += issue_msg.getPoints();
 			max_points += issue_msg.getMaxPoints();
 		}
-		
-		//log.warn("ALT TEXT AUDIT SCORE ::  "+ points_earned + " / " + max_points);
+
 		String description = "Applet elements without alternative text defined as a non empty string value";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,

--- a/src/main/java/com/looksee/contentAudit/models/CanvasAltTextAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/CanvasAltTextAudit.java
@@ -8,8 +8,6 @@ import java.util.Set;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -50,9 +48,6 @@ import lombok.NoArgsConstructor;
 @Component
 @NoArgsConstructor
 public class CanvasAltTextAudit implements IExecutablePageStateAudit {
-	@SuppressWarnings("unused")
-	private static Logger log = LoggerFactory.getLogger(ImageAltTextAudit.class);
-	
 	@Autowired
 	private AuditService audit_service;
 	
@@ -222,8 +217,7 @@ public class CanvasAltTextAudit implements IExecutablePageStateAudit {
 			points_earned += issue_msg.getPoints();
 			max_points += issue_msg.getMaxPoints();
 		}
-		
-		//log.warn("ALT TEXT AUDIT SCORE ::  "+ points_earned + " / " + max_points);
+
 		String description = "Audio/Video tags should have <track> defined and fall-back text that includes a link to a transcript for the audio/video.";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,

--- a/src/main/java/com/looksee/contentAudit/models/FigureAltTextAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/FigureAltTextAudit.java
@@ -8,8 +8,6 @@ import java.util.Set;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -49,9 +47,6 @@ import lombok.NoArgsConstructor;
 @Component
 @NoArgsConstructor
 public class FigureAltTextAudit implements IExecutablePageStateAudit {
-	@SuppressWarnings("unused")
-	private static Logger log = LoggerFactory.getLogger(ImageAltTextAudit.class);
-	
 	@Autowired
 	private AuditService audit_service;
 	
@@ -175,8 +170,7 @@ public class FigureAltTextAudit implements IExecutablePageStateAudit {
 			points_earned += issue_msg.getPoints();
 			max_points += issue_msg.getMaxPoints();
 		}
-		
-		//log.warn("ALT TEXT AUDIT SCORE ::  "+ points_earned + " / " + max_points);
+
 		String description = "figure tags should have <figcaption> elements and they should not be empty";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,

--- a/src/main/java/com/looksee/contentAudit/models/IframeAltTextAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/IframeAltTextAudit.java
@@ -8,8 +8,6 @@ import java.util.Set;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -49,9 +47,6 @@ import lombok.NoArgsConstructor;
 @Component
 @NoArgsConstructor
 public class IframeAltTextAudit implements IExecutablePageStateAudit {
-	@SuppressWarnings("unused")
-	private static Logger log = LoggerFactory.getLogger(ImageAltTextAudit.class);
-	
 	@Autowired
 	private AuditService audit_service;
 	
@@ -179,8 +174,7 @@ public class IframeAltTextAudit implements IExecutablePageStateAudit {
 			points_earned += issue_msg.getPoints();
 			max_points += issue_msg.getMaxPoints();
 		}
-		
-		//log.warn("ALT TEXT AUDIT SCORE ::  "+ points_earned + " / " + max_points);
+
 		String description = "Images without alternative text defined as a non empty string value";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,

--- a/src/main/java/com/looksee/contentAudit/models/ImageAltTextAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/ImageAltTextAudit.java
@@ -8,8 +8,6 @@ import java.util.Set;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -51,9 +49,6 @@ import lombok.NoArgsConstructor;
 @Component
 @NoArgsConstructor
 public class ImageAltTextAudit implements IExecutablePageStateAudit {
-	@SuppressWarnings("unused")
-	private static Logger log = LoggerFactory.getLogger(ImageAltTextAudit.class);
-	
 	@Autowired
 	private AuditService audit_service;
 	
@@ -208,24 +203,8 @@ public class ImageAltTextAudit implements IExecutablePageStateAudit {
 		for(UXIssueMessage issue_msg : issue_messages) {
 			points_earned += issue_msg.getPoints();
 			max_points += issue_msg.getMaxPoints();
-			/*
-			if(issue_msg.getScore() < 90 && issue_msg instanceof ElementStateIssueMessage) {
-				ElementStateIssueMessage element_issue_msg = (ElementStateIssueMessage)issue_msg;
-				
-				List<ElementState> good_examples = audit_service.findGoodExample(AuditName.ALT_TEXT, 100);
-				if(good_examples.isEmpty()) {
-					log.warn("Could not find element for good example...");
-					continue;
-				}
-				Random random = new Random();
-				ElementState good_example = good_examples.get(random.nextInt(good_examples.size()-1));
-				element_issue_msg.setGoodExample(good_example);
-				issue_message_service.save(element_issue_msg);
-			}
-			*/
 		}
-		
-		//log.warn("ALT TEXT AUDIT SCORE ::  "+ points_earned + " / " + max_points);
+
 		String description = "Images without alternative text defined as a non empty string value";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,

--- a/src/main/java/com/looksee/contentAudit/models/ObjectAltTextAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/ObjectAltTextAudit.java
@@ -8,8 +8,6 @@ import java.util.Set;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -50,9 +48,6 @@ import lombok.NoArgsConstructor;
 @Component
 @NoArgsConstructor
 public class ObjectAltTextAudit implements IExecutablePageStateAudit {
-	@SuppressWarnings("unused")
-	private static Logger log = LoggerFactory.getLogger(ImageAltTextAudit.class);
-	
 	@Autowired
 	private AuditService audit_service;
 	
@@ -188,8 +183,7 @@ public class ObjectAltTextAudit implements IExecutablePageStateAudit {
 			points_earned += issue_msg.getPoints();
 			max_points += issue_msg.getMaxPoints();
 		}
-		
-		//log.warn("ALT TEXT AUDIT SCORE ::  "+ points_earned + " / " + max_points);
+
 		String description = "Inputs and other controls should have alternative text defined as a non empty string value";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,

--- a/src/main/java/com/looksee/contentAudit/models/ParagraphingAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/ParagraphingAudit.java
@@ -49,7 +49,6 @@ import lombok.NoArgsConstructor;
 @Component
 @NoArgsConstructor
 public class ParagraphingAudit implements IExecutablePageStateAudit {
-	@SuppressWarnings("unused")
 	private static Logger log = LoggerFactory.getLogger(ParagraphingAudit.class);
 	
 	@Autowired
@@ -155,20 +154,6 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 		for(UXIssueMessage issue_msg : issue_messages) {
 			points_earned += issue_msg.getPoints();
 			max_points += issue_msg.getMaxPoints();
-			/*
-			if(issue_msg.getScore() < 90 && issue_msg instanceof ElementStateIssueMessage) {
-				ElementStateIssueMessage element_issue_msg = (ElementStateIssueMessage)issue_msg;
-				List<ElementState> good_examples = audit_service.findGoodExample(AuditName.ALT_TEXT, 100);
-				if(good_examples.isEmpty()) {
-					log.warn("Could not find element for good example...");
-					continue;
-				}
-				Random random = new Random();
-				ElementState good_example = good_examples.get(random.nextInt(good_examples.size()-1));
-				element_issue_msg.setGoodExample(good_example);
-				issue_message_service.save(element_issue_msg);
-			}
-			*/
 		}
 		
 		String description = "";
@@ -200,7 +185,6 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 	 * @return
 	 */
 	public Score calculateSentenceScore(List<Sentence> sentences, ElementState element) {
-		//    		for each sentence check that sentence is no longer than 25 words
 		int points_earned = 0;
 		int max_points = 0;
 		Set<UXIssueMessage> issue_messages = new HashSet<>();
@@ -217,7 +201,6 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 			
 			if(words.length > 25) {
 
-				//return new Score(1, 1, new HashSet<>());
 				String recommendation = "Try reducing the size of the sentence or breaking it up into multiple sentences";
 				String title = "Sentence is too long";
 				String description = "The sentence  \"" + sentence.getText().getContent() + "\" has more than 25 words which can make it difficult for users to understand";
@@ -236,9 +219,8 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 																words.length);
 				
 				issue_message = (SentenceIssueMessage) issue_message_service.save(issue_message);
-				//issue_message_service.addElement(issue_message.getId(), element.getId());
 				issue_messages.add(issue_message);
-				
+
 				max_points += 1;
 			}
 			else {
@@ -247,11 +229,11 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 				String recommendation = "";
 				String title = "Sentence meets EU and US governmental standards for sentence length";
 				String description = "The sentence  \"" + sentence.getText().getContent() + "\" has less than 25 words which is the standard for governmental documentation in the European Union(EU) and the United States(US)";
-				
+
 				SentenceIssueMessage issue_message = new SentenceIssueMessage(
-																Priority.NONE, 
-																description, 
-																recommendation, 
+																Priority.NONE,
+																description,
+																recommendation,
 																element,
 																AuditCategory.CONTENT,
 																labels,
@@ -260,9 +242,8 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 																1,
 																1,
 																words.length);
-				
+
 				issue_message = (SentenceIssueMessage) issue_message_service.save(issue_message);
-				//issue_message_service.addElement(issue_message.getId(), element.getId());
 				issue_messages.add(issue_message);
 			}
 		}
@@ -282,7 +263,5 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 		}
 
 		return new Score(0, 1, new HashSet<>());
-		//	  		Verify that there are no more than 5 sentences
-		// validate that spacing between paragraphs is at least 2x the font size within the paragraphs
 	}
 }

--- a/src/main/java/com/looksee/contentAudit/models/ReadabilityAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/ReadabilityAudit.java
@@ -53,7 +53,6 @@ import lombok.NoArgsConstructor;
 @Component
 @NoArgsConstructor
 public class ReadabilityAudit implements IExecutablePageStateAudit {
-	@SuppressWarnings("unused")
 	private static Logger log = LoggerFactory.getLogger(ReadabilityAudit.class);
 	
 	@Autowired
@@ -481,7 +480,6 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 	 * @return A score based on the number of words in the sentence.
 	 */
 	public static Score calculateSentenceScore(String sentence) {
-		//    		for each sentence check that sentence is no longer than 20 words
 		String[] words = sentence == null || sentence.isBlank() ? new String[0] : sentence.trim().split("\\s+");
 		
 		if(words.length <= 10) {
@@ -508,7 +506,5 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 		}
 
 		return new Score(0, 1, new HashSet<>());
-		//	  		Verify that there are no more than 5 sentences
-		// validate that spacing between paragraphs is at least 2x the font size within the paragraphs
 	}
 }

--- a/src/main/java/com/looksee/contentAudit/models/SVGAltTextAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/SVGAltTextAudit.java
@@ -8,8 +8,6 @@ import java.util.Set;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -52,9 +50,6 @@ import lombok.NoArgsConstructor;
 @Component
 @NoArgsConstructor
 public class SVGAltTextAudit implements IExecutablePageStateAudit {
-	@SuppressWarnings("unused")
-	private static Logger log = LoggerFactory.getLogger(ImageAltTextAudit.class);
-	
 	@Autowired
 	private AuditService audit_service;
 	
@@ -229,8 +224,7 @@ public class SVGAltTextAudit implements IExecutablePageStateAudit {
 			points_earned += issue_msg.getPoints();
 			max_points += issue_msg.getMaxPoints();
 		}
-		
-		//log.warn("ALT TEXT AUDIT SCORE ::  "+ points_earned + " / " + max_points);
+
 		String description = "SVG tags should have <title> and <desc> elements and they should not be empty";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,


### PR DESCRIPTION
Remove 5 unused Maven dependencies (xsoup, xml-apis, jtidy, stanford-corenlp,
swagger-annotations) that had no imports in the codebase. Remove unused logger
fields and their imports from 8 audit classes where logging was never used.
Remove @SuppressWarnings("unused") from loggers that are actually used in
ParagraphingAudit and ReadabilityAudit. Clean up commented-out code blocks
across all audit model files and AuditController.

https://claude.ai/code/session_01XKKA4GXrLeqaDA1VAaKFzP