### PR TITLE
Enforce Design by Contract with runtime preconditions, postconditions, and invariants

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,49 @@ The controller expects a Pub/Sub push body with base64-encoded JSON in `message.
 - `pageId`
 - `accountId`
 
+## Design by Contract
+
+This codebase follows [Design by Contract](https://en.wikipedia.org/wiki/Design_by_contract) (DbC) principles to enforce correctness at method boundaries. Every public and significant private method documents and enforces its contract through three mechanisms:
+
+### Preconditions
+
+Preconditions validate that callers satisfy required input constraints before a method executes. They are enforced at runtime using `Objects.requireNonNull()` (which throws `NullPointerException`) and `IllegalArgumentException` for invalid argument values. Preconditions are **always active** regardless of JVM assertion settings.
+
+Examples:
+- All `execute()` methods on audit classes require a non-null `page_state`
+- `ReadabilityAudit.execute()` additionally requires a non-null `audit_record`
+- `calculateParagraphScore()` requires a non-negative `sentence_count`
+
+### Postconditions
+
+Postconditions verify that methods produce valid results. They are enforced using `assert` statements at method exit points, validating return values and side effects.
+
+Examples:
+- All `execute()` methods assert the saved audit object is non-null after persistence
+- `getPointsForEducationLevel()` asserts the returned score is in the valid range [0, 4]
+
+### Invariants
+
+Invariants enforce conditions that must always hold true during execution. They are checked using `assert` statements at critical points within method bodies.
+
+Examples:
+- All audit score calculations assert `points_earned <= max_points`
+- Class-level invariants documented in JavaDoc (e.g., `AuditController` requires all `@Autowired` dependencies to be non-null)
+
+### Contract documentation
+
+All contracts are documented in JavaDoc using structured `<strong>Preconditions</strong>`, `<strong>Postconditions</strong>`, and `<strong>Invariants</strong>` sections. Contract violations are declared via `@throws` tags.
+
+### Enabling assertion checks
+
+Postcondition and invariant assertions require the `-ea` JVM flag to be active at runtime:
+
+```bash
+java -ea -jar target/content-audit-<version>.jar
+```
+
+Precondition checks (`Objects.requireNonNull`, `IllegalArgumentException`) are always enforced regardless of this flag.
+
 ## Reliability and validation improvements
 
 Recent code review fixes include:

--- a/src/main/java/com/looksee/contentAudit/AuditController.java
+++ b/src/main/java/com/looksee/contentAudit/AuditController.java
@@ -19,6 +19,7 @@ package com.looksee.contentAudit;
 // [START run_pubsub_handler]
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -59,6 +60,13 @@ import com.looksee.services.PageStateService;
 
 /**
  * API controller that performs a content audit.
+ *
+ * <p><strong>Class Invariants:</strong></p>
+ * <ul>
+ *   <li>All {@code @Autowired} dependencies must be non-null after Spring initialization</li>
+ *   <li>The controller only processes valid Pub/Sub push payloads with base64-encoded {@link PageAuditMessage} JSON</li>
+ *   <li>Invalid or malformed messages are acknowledged with HTTP 200 to prevent Pub/Sub redelivery of poison messages</li>
+ * </ul>
  */
 @RestController
 public class AuditController {
@@ -99,6 +107,21 @@ public class AuditController {
 	
 	/**
 	 * Receives a message from Pub/Sub and performs a content audit on the page.
+	 *
+	 * <p><strong>Preconditions:</strong></p>
+	 * <ul>
+	 *   <li>{@code body} should contain a valid Pub/Sub push payload (null/invalid payloads are handled gracefully)</li>
+	 *   <li>{@code body.getMessage().getData()} should contain base64-encoded {@link PageAuditMessage} JSON</li>
+	 *   <li>The decoded {@code PageAuditMessage} must have a positive {@code pageAuditId}</li>
+	 * </ul>
+	 *
+	 * <p><strong>Postconditions:</strong></p>
+	 * <ul>
+	 *   <li>Returns a non-null {@link ResponseEntity} with HTTP 200 for valid or gracefully-handled invalid messages</li>
+	 *   <li>Returns HTTP 500 only for unexpected internal errors during audit execution</li>
+	 *   <li>On success, all applicable audits (alt text, readability, paragraphing) are persisted and linked to the audit record</li>
+	 *   <li>An {@link AuditProgressUpdate} message is published to notify downstream systems of completion</li>
+	 * </ul>
 	 *
 	 * @param body the body of the message containing the audit record and page state
 	 * @return ResponseEntity containing the result of the audit
@@ -207,25 +230,51 @@ public class AuditController {
 	}
 	
 	/**
-	 * Checks if the any of the provided {@link Audit audits} have a name that matches
-	 * 		the provided {@linkplain AuditName}
+	 * Acknowledges an invalid Pub/Sub message by returning HTTP 200 to prevent redelivery.
 	 *
-	 * @param audits
-	 * @param audit_name
+	 * <p><strong>Preconditions:</strong></p>
+	 * <ul>
+	 *   <li>{@code reason} must not be null</li>
+	 * </ul>
 	 *
-	 * @return
+	 * <p><strong>Postconditions:</strong></p>
+	 * <ul>
+	 *   <li>Returns a non-null {@link ResponseEntity} with HTTP 200 status</li>
+	 * </ul>
 	 *
-	 * @pre audits != null
-	 * @pre audit_name != null
+	 * @param reason the reason the message is invalid, must not be null
+	 * @return ResponseEntity with HTTP 200 and the reason as body
+	 * @throws NullPointerException if {@code reason} is null
 	 */
-
 	private ResponseEntity<String> acknowledgeInvalidMessage(String reason) {
+		Objects.requireNonNull(reason, "reason must not be null");
 		return new ResponseEntity<String>(reason, HttpStatus.OK);
 	}
 
+	/**
+	 * Checks if any of the provided {@link Audit audits} have a name that matches
+	 * the provided {@linkplain AuditName}.
+	 *
+	 * <p><strong>Preconditions:</strong></p>
+	 * <ul>
+	 *   <li>{@code audits} must not be null</li>
+	 *   <li>{@code audit_name} must not be null</li>
+	 * </ul>
+	 *
+	 * <p><strong>Postconditions:</strong></p>
+	 * <ul>
+	 *   <li>Returns {@code true} if any audit in the set has a matching name, {@code false} otherwise</li>
+	 *   <li>The input set is not modified</li>
+	 * </ul>
+	 *
+	 * @param audits the set of existing audits to search, must not be null
+	 * @param audit_name the audit name to search for, must not be null
+	 * @return {@code true} if a matching audit exists, {@code false} otherwise
+	 * @throws NullPointerException if {@code audits} or {@code audit_name} is null
+	 */
 	private boolean auditAlreadyExists(Set<Audit> audits, AuditName audit_name) {
-		assert audits != null;
-		assert audit_name != null;
+		Objects.requireNonNull(audits, "audits must not be null");
+		Objects.requireNonNull(audit_name, "audit_name must not be null");
 		
 		for(Audit audit : audits) {
 			if(audit_name.equals(audit.getName())) {

--- a/src/main/java/com/looksee/contentAudit/models/AppletAltTextAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/AppletAltTextAudit.java
@@ -3,6 +3,7 @@ package com.looksee.contentAudit.models;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.jsoup.Jsoup;
@@ -93,12 +94,14 @@ public class AppletAltTextAudit implements IExecutablePageStateAudit {
 	 * @param audit_record The audit record for tracking this audit execution
 	 * @param design_system The design system context (unused in this implementation)
 	 * @return A completed Audit object with accessibility compliance results for applet elements
+	 * @throws NullPointerException if {@code page_state} is null
 	 */
 	@Override
 	public Audit execute(PageState page_state,
 						AuditRecord audit_record,
 						DesignSystem design_system) {
-		assert page_state != null;
+		// Preconditions
+		Objects.requireNonNull(page_state, "page_state must not be null");
 		
 		Set<UXIssueMessage> issue_messages = new HashSet<>();
 
@@ -173,6 +176,9 @@ public class AppletAltTextAudit implements IExecutablePageStateAudit {
 			max_points += issue_msg.getMaxPoints();
 		}
 
+		// Invariant: points earned cannot exceed max points
+		assert points_earned <= max_points : "points_earned (" + points_earned + ") exceeds max_points (" + max_points + ")";
+
 		String description = "Applet elements without alternative text defined as a non empty string value";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,
@@ -189,7 +195,10 @@ public class AppletAltTextAudit implements IExecutablePageStateAudit {
 
 		audit = audit_service.save(audit);
 		audit_service.addAllIssues(audit.getId(), issue_messages);
-		
+
+		// Postcondition: audit must be non-null and persisted
+		assert audit != null : "audit must not be null after save";
+
 		return audit;
 	}
 }

--- a/src/main/java/com/looksee/contentAudit/models/CanvasAltTextAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/CanvasAltTextAudit.java
@@ -3,6 +3,7 @@ package com.looksee.contentAudit.models;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.jsoup.Jsoup;
@@ -96,10 +97,12 @@ public class CanvasAltTextAudit implements IExecutablePageStateAudit {
 	 * @param audit_record The audit record for tracking this audit execution
 	 * @param design_system The design system context (unused in this implementation)
 	 * @return A completed Audit object with accessibility compliance results for video and audio elements
+	 * @throws NullPointerException if {@code page_state} is null
 	 */
 	@Override
-	public Audit execute(PageState page_state, AuditRecord audit_record, DesignSystem design_system) { 
-		assert page_state != null;
+	public Audit execute(PageState page_state, AuditRecord audit_record, DesignSystem design_system) {
+		// Preconditions
+		Objects.requireNonNull(page_state, "page_state must not be null");
 		
 		Set<UXIssueMessage> issue_messages = new HashSet<>();
 
@@ -218,6 +221,9 @@ public class CanvasAltTextAudit implements IExecutablePageStateAudit {
 			max_points += issue_msg.getMaxPoints();
 		}
 
+		// Invariant: points earned cannot exceed max points
+		assert points_earned <= max_points : "points_earned (" + points_earned + ") exceeds max_points (" + max_points + ")";
+
 		String description = "Audio/Video tags should have <track> defined and fall-back text that includes a link to a transcript for the audio/video.";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,
@@ -231,10 +237,13 @@ public class CanvasAltTextAudit implements IExecutablePageStateAudit {
 								 why_it_matters,
 								 description,
 								 true);
-								 
+
 		audit = audit_service.save(audit);
 		audit_service.addAllIssues(audit.getId(), issue_messages);
-		
+
+		// Postcondition: audit must be non-null and persisted
+		assert audit != null : "audit must not be null after save";
+
 		return audit;
 	}
 }

--- a/src/main/java/com/looksee/contentAudit/models/FigureAltTextAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/FigureAltTextAudit.java
@@ -3,6 +3,7 @@ package com.looksee.contentAudit.models;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.jsoup.Jsoup;
@@ -93,12 +94,14 @@ public class FigureAltTextAudit implements IExecutablePageStateAudit {
 	 * @param audit_record The audit record for tracking this audit execution
 	 * @param design_system The design system context (unused in this implementation)
 	 * @return A completed Audit object with accessibility compliance results for figure elements
+	 * @throws NullPointerException if {@code page_state} is null
 	 */
 	@Override
 	public Audit execute(PageState page_state,
 						AuditRecord audit_record,
 						DesignSystem design_system) {
-		assert page_state != null;
+		// Preconditions
+		Objects.requireNonNull(page_state, "page_state must not be null");
 		
 		Set<UXIssueMessage> issue_messages = new HashSet<>();
 
@@ -171,6 +174,9 @@ public class FigureAltTextAudit implements IExecutablePageStateAudit {
 			max_points += issue_msg.getMaxPoints();
 		}
 
+		// Invariant: points earned cannot exceed max points
+		assert points_earned <= max_points : "points_earned (" + points_earned + ") exceeds max_points (" + max_points + ")";
+
 		String description = "figure tags should have <figcaption> elements and they should not be empty";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,
@@ -184,11 +190,13 @@ public class FigureAltTextAudit implements IExecutablePageStateAudit {
 								why_it_matters,
 								description,
 								true);
-								
+
 		audit = audit_service.save(audit);
 		audit_service.addAllIssues(audit.getId(), issue_messages);
-		
+
+		// Postcondition: audit must be non-null and persisted
+		assert audit != null : "audit must not be null after save";
+
 		return audit;
-	
 	}
 }

--- a/src/main/java/com/looksee/contentAudit/models/IframeAltTextAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/IframeAltTextAudit.java
@@ -3,6 +3,7 @@ package com.looksee.contentAudit.models;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.jsoup.Jsoup;
@@ -98,10 +99,12 @@ public class IframeAltTextAudit implements IExecutablePageStateAudit {
 	 * @param audit_record The audit record for tracking this audit execution
 	 * @param design_system The design system context (unused in this implementation)
 	 * @return A completed Audit object with accessibility compliance results for iframe elements
+	 * @throws NullPointerException if {@code page_state} is null
 	 */
 	@Override
-	public Audit execute(PageState page_state, AuditRecord audit_record, DesignSystem design_system) { 
-		assert page_state != null;
+	public Audit execute(PageState page_state, AuditRecord audit_record, DesignSystem design_system) {
+		// Preconditions
+		Objects.requireNonNull(page_state, "page_state must not be null");
 		
 		Set<UXIssueMessage> issue_messages = new HashSet<>();
 
@@ -175,6 +178,9 @@ public class IframeAltTextAudit implements IExecutablePageStateAudit {
 			max_points += issue_msg.getMaxPoints();
 		}
 
+		// Invariant: points earned cannot exceed max points
+		assert points_earned <= max_points : "points_earned (" + points_earned + ") exceeds max_points (" + max_points + ")";
+
 		String description = "Images without alternative text defined as a non empty string value";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,
@@ -188,10 +194,13 @@ public class IframeAltTextAudit implements IExecutablePageStateAudit {
 								 why_it_matters,
 								 description,
 								 true);
-								 
+
 		audit = audit_service.save(audit);
 		audit_service.addAllIssues(audit.getId(), issue_messages);
-		
+
+		// Postcondition: audit must be non-null and persisted
+		assert audit != null : "audit must not be null after save";
+
 		return audit;
 	}
 }

--- a/src/main/java/com/looksee/contentAudit/models/ImageAltTextAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/ImageAltTextAudit.java
@@ -3,6 +3,7 @@ package com.looksee.contentAudit.models;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.jsoup.Jsoup;
@@ -95,12 +96,14 @@ public class ImageAltTextAudit implements IExecutablePageStateAudit {
 	 * @param audit_record The audit record for tracking this audit execution
 	 * @param design_system The design system context (unused in this implementation)
 	 * @return A completed Audit object with accessibility compliance results for area, input, and embed elements
+	 * @throws NullPointerException if {@code page_state} is null
 	 */
 	@Override
 	public Audit execute(PageState page_state,
 						AuditRecord audit_record,
 						DesignSystem design_system) {
-		assert page_state != null;
+		// Preconditions
+		Objects.requireNonNull(page_state, "page_state must not be null");
 		
 		Set<UXIssueMessage> issue_messages = new HashSet<>();
 
@@ -205,6 +208,9 @@ public class ImageAltTextAudit implements IExecutablePageStateAudit {
 			max_points += issue_msg.getMaxPoints();
 		}
 
+		// Invariant: points earned cannot exceed max points
+		assert points_earned <= max_points : "points_earned (" + points_earned + ") exceeds max_points (" + max_points + ")";
+
 		String description = "Images without alternative text defined as a non empty string value";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,
@@ -221,7 +227,10 @@ public class ImageAltTextAudit implements IExecutablePageStateAudit {
 
 		audit = audit_service.save(audit);
 		audit_service.addAllIssues(audit.getId(), issue_messages);
-		
+
+		// Postcondition: audit must be non-null and persisted
+		assert audit != null : "audit must not be null after save";
+
 		return audit;
 	}
 }

--- a/src/main/java/com/looksee/contentAudit/models/ObjectAltTextAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/ObjectAltTextAudit.java
@@ -3,6 +3,7 @@ package com.looksee.contentAudit.models;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.jsoup.Jsoup;
@@ -101,12 +102,14 @@ public class ObjectAltTextAudit implements IExecutablePageStateAudit {
 	 * @param audit_record The audit record for tracking this audit execution
 	 * @param design_system The design system context (unused in this implementation)
 	 * @return A completed Audit object with accessibility compliance results for object and canvas elements
+	 * @throws NullPointerException if {@code page_state} is null
 	 */
 	@Override
 	public Audit execute(PageState page_state,
 						AuditRecord audit_record,
 						DesignSystem design_system) {
-		assert page_state != null;
+		// Preconditions
+		Objects.requireNonNull(page_state, "page_state must not be null");
 		
 		Set<UXIssueMessage> issue_messages = new HashSet<>();
 
@@ -184,6 +187,9 @@ public class ObjectAltTextAudit implements IExecutablePageStateAudit {
 			max_points += issue_msg.getMaxPoints();
 		}
 
+		// Invariant: points earned cannot exceed max points
+		assert points_earned <= max_points : "points_earned (" + points_earned + ") exceeds max_points (" + max_points + ")";
+
 		String description = "Inputs and other controls should have alternative text defined as a non empty string value";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,
@@ -200,7 +206,10 @@ public class ObjectAltTextAudit implements IExecutablePageStateAudit {
 
 		audit = audit_service.save(audit);
 		audit_service.addAllIssues(audit.getId(), issue_messages);
-		
+
+		// Postcondition: audit must be non-null and persisted
+		assert audit != null : "audit must not be null after save";
+
 		return audit;
 	}
 }

--- a/src/main/java/com/looksee/contentAudit/models/ParagraphingAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/ParagraphingAudit.java
@@ -2,6 +2,7 @@ package com.looksee.contentAudit.models;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -102,13 +103,15 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 	 * @param audit_record The audit record for tracking this audit execution
 	 * @param design_system The design system context (unused in this implementation)
 	 * @return A completed Audit object with paragraphing compliance results
+	 * @throws NullPointerException if {@code page_state} is null
 	 * @throws RuntimeException if CloudNLPUtils.extractSentences() fails for any paragraph
 	 */
 	@Override
 	public Audit execute(PageState page_state,
 						AuditRecord audit_record,
 						DesignSystem design_system) {
-		assert page_state != null;
+		// Preconditions
+		Objects.requireNonNull(page_state, "page_state must not be null");
 
 		Set<UXIssueMessage> issue_messages = new HashSet<>();
 		
@@ -155,7 +158,10 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 			points_earned += issue_msg.getPoints();
 			max_points += issue_msg.getMaxPoints();
 		}
-		
+
+		// Invariant: points earned cannot exceed max points
+		assert points_earned <= max_points : "points_earned (" + points_earned + ") exceeds max_points (" + max_points + ")";
+
 		String description = "";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,
@@ -172,6 +178,10 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 
 		audit = audit_service.save(audit);
 		audit_service.addAllIssues(audit.getId(), issue_messages);
+
+		// Postcondition: audit must be non-null and persisted
+		assert audit != null : "audit must not be null after save";
+
 		return audit;
 	}
 
@@ -179,12 +189,30 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 	/**
 	 * Reviews list of sentences and gives a score based on how many of those
 	 * sentences have 25 words or less. This is considered the maximum sentence
-	 * length allowed in EU government documentation
-	 * @param sentences
-	 * @param element
-	 * @return
+	 * length allowed in EU government documentation.
+	 *
+	 * <p><strong>Preconditions:</strong></p>
+	 * <ul>
+	 *   <li>{@code sentences} must not be null</li>
+	 *   <li>{@code element} must not be null</li>
+	 * </ul>
+	 *
+	 * <p><strong>Postconditions:</strong></p>
+	 * <ul>
+	 *   <li>Returns a non-null {@link Score} object</li>
+	 *   <li>Points earned does not exceed max points</li>
+	 *   <li>Each sentence contributes exactly 1 to max points</li>
+	 *   <li>All generated {@link SentenceIssueMessage} objects are persisted</li>
+	 * </ul>
+	 *
+	 * @param sentences The list of sentences to evaluate, must not be null
+	 * @param element The element containing the sentences, must not be null
+	 * @return A non-null Score with points earned, max points, and associated issue messages
+	 * @throws NullPointerException if {@code sentences} or {@code element} is null
 	 */
 	public Score calculateSentenceScore(List<Sentence> sentences, ElementState element) {
+		Objects.requireNonNull(sentences, "sentences must not be null");
+		Objects.requireNonNull(element, "element must not be null");
 		int points_earned = 0;
 		int max_points = 0;
 		Set<UXIssueMessage> issue_messages = new HashSet<>();
@@ -247,17 +275,36 @@ public class ParagraphingAudit implements IExecutablePageStateAudit {
 				issue_messages.add(issue_message);
 			}
 		}
+
+		// Invariant: points earned cannot exceed max points
+		assert points_earned <= max_points : "points_earned (" + points_earned + ") exceeds max_points (" + max_points + ")";
+
 		return new Score(points_earned, max_points, issue_messages);
 	}
 
 	/**
 	 * Calculates the score for a paragraph based on the number of sentences in the paragraph.
-	 * If the paragraph has 5 or fewer sentences, it returns a score of 1.
-	 * If the paragraph has more than 5 sentences, it returns a score of 0.
-	 * @param sentence_count
-	 * @return
+	 *
+	 * <p><strong>Preconditions:</strong></p>
+	 * <ul>
+	 *   <li>{@code sentence_count} must be non-negative</li>
+	 * </ul>
+	 *
+	 * <p><strong>Postconditions:</strong></p>
+	 * <ul>
+	 *   <li>Returns a non-null {@link Score} object</li>
+	 *   <li>Score is 1 for paragraphs with 5 or fewer sentences, 0 otherwise</li>
+	 *   <li>Max points is always 1</li>
+	 * </ul>
+	 *
+	 * @param sentence_count The number of sentences in the paragraph, must be non-negative
+	 * @return A non-null Score based on the number of sentences in the paragraph.
+	 * @throws IllegalArgumentException if {@code sentence_count} is negative
 	 */
 	public static Score calculateParagraphScore(int sentence_count) {
+		if (sentence_count < 0) {
+			throw new IllegalArgumentException("sentence_count must be non-negative, got: " + sentence_count);
+		}
 		if(sentence_count <= 5) {
 			return new Score(1, 1, new HashSet<>());
 		}

--- a/src/main/java/com/looksee/contentAudit/models/ReadabilityAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/ReadabilityAudit.java
@@ -3,6 +3,7 @@ package com.looksee.contentAudit.models;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -117,14 +118,17 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 	 * </ul>
 	 * 
 	 * @param page_state The page state containing elements to audit, must not be null
-	 * @param audit_record The audit record for tracking this audit execution
+	 * @param audit_record The audit record for tracking this audit execution, must not be null
 	 * @param design_system The design system context (unused in this implementation)
 	 * @return A completed Audit object with readability compliance results
+	 * @throws NullPointerException if {@code page_state} or {@code audit_record} is null
 	 * @throws RuntimeException if ReadabilityCalculator.calculateReadingEase() fails for any text element
 	 */
 	@Override
 	public Audit execute(PageState page_state, AuditRecord audit_record, DesignSystem design_system) {
-		assert page_state != null;
+		// Preconditions
+		Objects.requireNonNull(page_state, "page_state must not be null");
+		Objects.requireNonNull(audit_record, "audit_record must not be null");
 		
 		Set<UXIssueMessage> issue_messages = new HashSet<>();
 		
@@ -271,6 +275,9 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 				max_points += issue_msg.getMaxPoints();
 			}
 
+			// Invariant: points earned cannot exceed max points
+			assert points_earned <= max_points : "points_earned (" + points_earned + ") exceeds max_points (" + max_points + ")";
+
 			String description = "";
 			Audit audit = new Audit(AuditCategory.CONTENT,
 									AuditSubcategory.WRITTEN_CONTENT,
@@ -283,8 +290,13 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 									why_it_matters,
 									description,
 									false);
-			
-			return audit_service.save(audit);
+
+			Audit saved_audit = audit_service.save(audit);
+
+			// Postcondition: audit must be non-null and persisted
+			assert saved_audit != null : "audit must not be null after save";
+
+			return saved_audit;
 		}
 		catch(Exception e){
 			log.error("readability audit failed", e);
@@ -295,15 +307,30 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 	/**
 	 * Generates a description of the issue based on the element, difficulty string,
 	 * and target user education.
-	 * @param element The element that is being audited
-	 * @param difficulty_string The difficulty string of the element
-	 * @param targetUserEducation The target user education of the element
+	 *
+	 * <p><strong>Preconditions:</strong></p>
+	 * <ul>
+	 *   <li>{@code element} must not be null</li>
+	 *   <li>{@code difficulty_string} must not be null</li>
+	 * </ul>
+	 *
+	 * <p><strong>Postconditions:</strong></p>
+	 * <ul>
+	 *   <li>Returns a non-null, non-empty description string</li>
+	 * </ul>
+	 *
+	 * @param element The element that is being audited, must not be null
+	 * @param difficulty_string The difficulty string of the element, must not be null
+	 * @param targetUserEducation The target user education of the element (may be null)
 	 * @return A description of the issue based on the element, difficulty string,
 	 * and target user education.
+	 * @throws NullPointerException if {@code element} or {@code difficulty_string} is null
 	 */
 	private String generateIssueDescription(ElementState element,
 									String difficulty_string,
 									String targetUserEducation) {
+		Objects.requireNonNull(element, "element must not be null");
+		Objects.requireNonNull(difficulty_string, "difficulty_string must not be null");
 		String description = "The text \"" + element.getAllText() + "\" is " + difficulty_string + " to read for " + getConsumerType(targetUserEducation) + ".";
 		
 		return description;
@@ -311,9 +338,16 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 
 
 	/**
-	 * Gets the consumer type based on the target user education.
-	 * @param targetUserEducation The target user education
-	 * @return The consumer type based on the target user education.
+	 * Gets the consumer type label based on the target user education.
+	 *
+	 * <p><strong>Postconditions:</strong></p>
+	 * <ul>
+	 *   <li>Returns a non-null, non-empty consumer type string</li>
+	 *   <li>Returns "the average consumer" if {@code targetUserEducation} is null</li>
+	 * </ul>
+	 *
+	 * @param targetUserEducation The target user education (may be null)
+	 * @return The consumer type label based on the target user education.
 	 */
 	private String getConsumerType(String targetUserEducation) {
 		String consumer_label = "the average consumer";
@@ -327,9 +361,17 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 
 	/**
 	 * Calculates the points for a given ease of reading score and target user education.
-	 * @param ease_of_reading_score The ease of reading score of the element
-	 * @param target_user_education The target user education of the element
-	 * @return The points for a given ease of reading score and target user education.
+	 *
+	 * <p><strong>Postconditions:</strong></p>
+	 * <ul>
+	 *   <li>Returns a value between 0 and 4, inclusive</li>
+	 *   <li>Higher ease of reading scores yield higher point values</li>
+	 *   <li>Higher target education levels yield higher point values for the same reading ease score</li>
+	 * </ul>
+	 *
+	 * @param ease_of_reading_score The Flesch Reading Ease score (0-100 scale)
+	 * @param target_user_education The target user education level (may be null; null treated as general audience)
+	 * @return The points earned, between 0 and 4 inclusive.
 	 */
 	private int getPointsForEducationLevel(double ease_of_reading_score, String target_user_education) {
 		int element_points = 0;
@@ -450,7 +492,10 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 				element_points = 0;
 			}
 		}
-		
+
+		// Postcondition: points must be in valid range [0, 4]
+		assert element_points >= 0 && element_points <= 4 : "element_points (" + element_points + ") out of valid range [0, 4]";
+
 		return element_points;
 	}
 
@@ -473,11 +518,17 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 
 	/**
 	 * Calculates the score for a sentence based on the number of words in the sentence.
-	 * If the sentence has 10 or fewer words, it returns a score of 2.
-	 * If the sentence has more than 10 words, it returns a score of 1.
-	 * If the sentence has more than 20 words, it returns a score of 0.
-	 * @param sentence The sentence to calculate the score for
-	 * @return A score based on the number of words in the sentence.
+	 *
+	 * <p><strong>Postconditions:</strong></p>
+	 * <ul>
+	 *   <li>Returns a non-null {@link Score} object</li>
+	 *   <li>Score points are 2 for sentences with 10 or fewer words, 1 for 11-20 words, 0 for more than 20 words</li>
+	 *   <li>Max points is always 2</li>
+	 *   <li>Points earned does not exceed max points</li>
+	 * </ul>
+	 *
+	 * @param sentence The sentence to calculate the score for (may be null or blank, treated as 0 words)
+	 * @return A non-null Score based on the number of words in the sentence.
 	 */
 	public static Score calculateSentenceScore(String sentence) {
 		String[] words = sentence == null || sentence.isBlank() ? new String[0] : sentence.trim().split("\\s+");
@@ -495,12 +546,27 @@ public class ReadabilityAudit implements IExecutablePageStateAudit {
 
 	/**
 	 * Calculates the score for a paragraph based on the number of sentences in the paragraph.
-	 * If the paragraph has 5 or fewer sentences, it returns a score of 1.
-	 * If the paragraph has more than 5 sentences, it returns a score of 0.
-	 * @param sentence_count The number of sentences in the paragraph
-	 * @return A score based on the number of sentences in the paragraph.
+	 *
+	 * <p><strong>Preconditions:</strong></p>
+	 * <ul>
+	 *   <li>{@code sentence_count} must be non-negative</li>
+	 * </ul>
+	 *
+	 * <p><strong>Postconditions:</strong></p>
+	 * <ul>
+	 *   <li>Returns a non-null {@link Score} object</li>
+	 *   <li>Score is 1 for paragraphs with 5 or fewer sentences, 0 otherwise</li>
+	 *   <li>Max points is always 1</li>
+	 * </ul>
+	 *
+	 * @param sentence_count The number of sentences in the paragraph, must be non-negative
+	 * @return A non-null Score based on the number of sentences in the paragraph.
+	 * @throws IllegalArgumentException if {@code sentence_count} is negative
 	 */
 	public static Score calculateParagraphScore(int sentence_count) {
+		if (sentence_count < 0) {
+			throw new IllegalArgumentException("sentence_count must be non-negative, got: " + sentence_count);
+		}
 		if(sentence_count <= 5) {
 			return new Score(1, 1, new HashSet<>());
 		}

--- a/src/main/java/com/looksee/contentAudit/models/SVGAltTextAudit.java
+++ b/src/main/java/com/looksee/contentAudit/models/SVGAltTextAudit.java
@@ -3,6 +3,7 @@ package com.looksee.contentAudit.models;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.jsoup.Jsoup;
@@ -104,12 +105,14 @@ public class SVGAltTextAudit implements IExecutablePageStateAudit {
 	 * @param audit_record The audit record for tracking this audit execution
 	 * @param design_system The design system context (unused in this implementation)
 	 * @return A completed Audit object with accessibility compliance results for SVG elements
+	 * @throws NullPointerException if {@code page_state} is null
 	 */
 	@Override
 	public Audit execute(PageState page_state,
 						AuditRecord audit_record,
 						DesignSystem design_system) {
-		assert page_state != null;
+		// Preconditions
+		Objects.requireNonNull(page_state, "page_state must not be null");
 		
 		Set<UXIssueMessage> issue_messages = new HashSet<>();
 
@@ -225,6 +228,9 @@ public class SVGAltTextAudit implements IExecutablePageStateAudit {
 			max_points += issue_msg.getMaxPoints();
 		}
 
+		// Invariant: points earned cannot exceed max points
+		assert points_earned <= max_points : "points_earned (" + points_earned + ") exceeds max_points (" + max_points + ")";
+
 		String description = "SVG tags should have <title> and <desc> elements and they should not be empty";
 
 		Audit audit = new Audit(AuditCategory.CONTENT,
@@ -241,7 +247,10 @@ public class SVGAltTextAudit implements IExecutablePageStateAudit {
 
 		audit = audit_service.save(audit);
 		audit_service.addAllIssues(audit.getId(), issue_messages);
-		
+
+		// Postcondition: audit must be non-null and persisted
+		assert audit != null : "audit must not be null after save";
+
 		return audit;
 	}
 }


### PR DESCRIPTION
Replace assert-based preconditions with Objects.requireNonNull for runtime
enforcement regardless of JVM assertion settings. Add postcondition assertions
to verify audit persistence, invariant assertions to validate scoring bounds
(points_earned <= max_points), and IllegalArgumentException checks for invalid
arguments. Update all JavaDoc with structured contract sections and @throws
tags. Add DbC documentation section to README.

https://claude.ai/code/session_01BYVHHcXj7Z2X3iz2A8fcAE